### PR TITLE
Proposition to manage rate-limit error in evaluate pipeline

### DIFF
--- a/src/api/evaluate/evaluate.py
+++ b/src/api/evaluate/evaluate.py
@@ -136,55 +136,6 @@ def run_orchestrator(research_context, product_context, assignment_context):
     }
 
 @trace
-# def evaluate_orchestrator(model_config, project_scope,  data_path):
-#     writer_evaluator = ArticleEvaluator(model_config, project_scope)
-
-#     data = []    
-#     eval_data = []
-#     print(f"\n===== Creating articles to evaluate using data provided in {data_path}")
-#     print("")
-#     with open(data_path) as f:
-#         for num, line in enumerate(f):
-#             row = json.loads(line)
-#             data.append(row)
-#             print(f"generating article {num +1}")
-#             eval_data.append(run_orchestrator(row["research_context"], row["product_context"], row["assignment_context"]))
-
-#     # write out eval data to a file so we can re-run evaluation on it
-#     with jsonlines.open(folder + '/eval_data.jsonl', 'w') as writer:
-#         for row in eval_data:
-#             writer.write(row)
-
-#     eval_data_path = folder + '/eval_data.jsonl'
-
-#     print(f"\n===== Evaluating the generated articles")
-#     eval_results = writer_evaluator(data_path=eval_data_path)
-#     import pandas as pd
-
-#     print("Evaluation summary:\n")
-#     print("View in Azure AI Studio at: " + str(eval_results['studio_url']))
-#     metrics = {key: [value] for key, value in eval_results['metrics'].items()}
-#     results_df = pd.DataFrame.from_dict(metrics)
-#     results_df_gpt_evals = results_df[['relevance.gpt_relevance', 'fluency.gpt_fluency', 'coherence.gpt_coherence','groundedness.gpt_groundedness']]
-#     results_df_content_safety = results_df[['violence.violence_defect_rate', 'self_harm.self_harm_defect_rate', 'hate_unfairness.hate_unfairness_defect_rate','sexual.sexual_defect_rate']]
-
-#     mean_df = results_df_gpt_evals.mean()
-#     print("\nAverage scores:")
-#     print(mean_df)
-
-#     content_safety_mean_df = results_df_content_safety.mean()
-#     print("\nContent safety average defect rate:")
-#     print(content_safety_mean_df)
-
-#     results_df.to_markdown(folder + '/eval_results.md')
-#     with open(folder + '/eval_results.md', 'a') as file:
-#         file.write("\n\nAverages scores:\n\n")
-#     mean_df.to_markdown(folder + '/eval_results.md', 'a')
-
-#     with jsonlines.open(folder + '/eval_results.jsonl', 'w') as writer:
-#         writer.write(eval_results)
-
-#     return eval_results
 def evaluate_orchestrator(model_config, project_scope, data_path):
     writer_evaluator = ArticleEvaluator(model_config, project_scope)
     data = []    

--- a/src/api/evaluate/evaluate.py
+++ b/src/api/evaluate/evaluate.py
@@ -136,9 +136,57 @@ def run_orchestrator(research_context, product_context, assignment_context):
     }
 
 @trace
-def evaluate_orchestrator(model_config, project_scope,  data_path):
-    writer_evaluator = ArticleEvaluator(model_config, project_scope)
+# def evaluate_orchestrator(model_config, project_scope,  data_path):
+#     writer_evaluator = ArticleEvaluator(model_config, project_scope)
 
+#     data = []    
+#     eval_data = []
+#     print(f"\n===== Creating articles to evaluate using data provided in {data_path}")
+#     print("")
+#     with open(data_path) as f:
+#         for num, line in enumerate(f):
+#             row = json.loads(line)
+#             data.append(row)
+#             print(f"generating article {num +1}")
+#             eval_data.append(run_orchestrator(row["research_context"], row["product_context"], row["assignment_context"]))
+
+#     # write out eval data to a file so we can re-run evaluation on it
+#     with jsonlines.open(folder + '/eval_data.jsonl', 'w') as writer:
+#         for row in eval_data:
+#             writer.write(row)
+
+#     eval_data_path = folder + '/eval_data.jsonl'
+
+#     print(f"\n===== Evaluating the generated articles")
+#     eval_results = writer_evaluator(data_path=eval_data_path)
+#     import pandas as pd
+
+#     print("Evaluation summary:\n")
+#     print("View in Azure AI Studio at: " + str(eval_results['studio_url']))
+#     metrics = {key: [value] for key, value in eval_results['metrics'].items()}
+#     results_df = pd.DataFrame.from_dict(metrics)
+#     results_df_gpt_evals = results_df[['relevance.gpt_relevance', 'fluency.gpt_fluency', 'coherence.gpt_coherence','groundedness.gpt_groundedness']]
+#     results_df_content_safety = results_df[['violence.violence_defect_rate', 'self_harm.self_harm_defect_rate', 'hate_unfairness.hate_unfairness_defect_rate','sexual.sexual_defect_rate']]
+
+#     mean_df = results_df_gpt_evals.mean()
+#     print("\nAverage scores:")
+#     print(mean_df)
+
+#     content_safety_mean_df = results_df_content_safety.mean()
+#     print("\nContent safety average defect rate:")
+#     print(content_safety_mean_df)
+
+#     results_df.to_markdown(folder + '/eval_results.md')
+#     with open(folder + '/eval_results.md', 'a') as file:
+#         file.write("\n\nAverages scores:\n\n")
+#     mean_df.to_markdown(folder + '/eval_results.md', 'a')
+
+#     with jsonlines.open(folder + '/eval_results.jsonl', 'w') as writer:
+#         writer.write(eval_results)
+
+#     return eval_results
+def evaluate_orchestrator(model_config, project_scope, data_path):
+    writer_evaluator = ArticleEvaluator(model_config, project_scope)
     data = []    
     eval_data = []
     print(f"\n===== Creating articles to evaluate using data provided in {data_path}")
@@ -150,17 +198,33 @@ def evaluate_orchestrator(model_config, project_scope,  data_path):
             print(f"generating article {num +1}")
             eval_data.append(run_orchestrator(row["research_context"], row["product_context"], row["assignment_context"]))
 
-    # write out eval data to a file so we can re-run evaluation on it
+    # Write out eval data to a file so we can re-run evaluation on it
     with jsonlines.open(folder + '/eval_data.jsonl', 'w') as writer:
         for row in eval_data:
             writer.write(row)
 
     eval_data_path = folder + '/eval_data.jsonl'
-
     print(f"\n===== Evaluating the generated articles")
-    eval_results = writer_evaluator(data_path=eval_data_path)
-    import pandas as pd
 
+    retries = 0
+    max_retries = 5
+    while retries < max_retries:
+        try:
+            eval_results = writer_evaluator(data_path=eval_data_path)
+            break
+        except Exception as e:
+            if 'rate_limit_exceeded' in str(e):
+                wait_time = (2 ** retries) + random.uniform(0, 1)
+                print(f"Rate limit exceeded. Retrying in {wait_time} seconds...")
+                time.sleep(wait_time)
+                retries += 1
+            else:
+                raise e
+
+    if retries == max_retries:
+        raise Exception("Max retries reached. Exiting...")
+
+    import pandas as pd
     print("Evaluation summary:\n")
     print("View in Azure AI Studio at: " + str(eval_results['studio_url']))
     metrics = {key: [value] for key, value in eval_results['metrics'].items()}

--- a/src/api/evaluate/evaluate.py
+++ b/src/api/evaluate/evaluate.py
@@ -136,8 +136,6 @@ def run_orchestrator(research_context, product_context, assignment_context):
     }
 
 @trace
-<<<<<<< HEAD
-=======
 # def evaluate_orchestrator(model_config, project_scope,  data_path):
 #     writer_evaluator = ArticleEvaluator(model_config, project_scope)
 
@@ -187,7 +185,6 @@ def run_orchestrator(research_context, product_context, assignment_context):
 #         writer.write(eval_results)
 
 #     return eval_results
->>>>>>> 5b0ce0f063a97885f5b7aa13f5e24bbb3ab655a5
 def evaluate_orchestrator(model_config, project_scope, data_path):
     writer_evaluator = ArticleEvaluator(model_config, project_scope)
     data = []    


### PR DESCRIPTION
adding a retry mechanism in evaluate_orchestrator to manage rate limit excedeed that fail the evaluate pipeline 
but please test to be sure :) (works on my codespace)